### PR TITLE
refactor: replace retry method with retryN for cleaner API

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,0 @@
-{
-  "enabledMcpjsonServers": [
-    "github"
-  ],
-  "enableAllProjectMcpServers": true
-}

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ dist-ssr
 *.sw?
 
 coverage
+.claude/settings.local.json
 .env

--- a/packages/core/src/kio.ts
+++ b/packages/core/src/kio.ts
@@ -1,5 +1,4 @@
 import { _KFields, KError, KFields, KNewRecord, KRecord } from "./data.ts";
-import { RetryPolicy } from "./retry/policy.ts";
 
 /**
  * Arguments for getting a single record from Kintone
@@ -308,28 +307,21 @@ export class KIO<E, A> {
   }
 
   /**
-   * Applies a retry policy to a KIO operation.
-   * @param policy - The retry policy to apply
-   * @returns An effect that will retry on failure according to the policy
+   * Retries a KIO operation the specified number of times on failure.
+   * @param times - The number of times to retry
+   * @returns An effect that will retry on failure the specified number of times
    *
    * @example
    * ```typescript
    * const kio = KIO.getRecord({ app: 1, id: 1 })
-   *   .retry({ kind: "Recurs", times: 3 });
+   *   .retryN(3);
    * ```
    */
-  retry(policy: RetryPolicy): KIO<E, A> {
-    return (() => {
-      switch (policy.kind) {
-        case "Recurs": {
-          const { times } = policy;
-          const loop = (n: number): KIO<E, A> => {
-            return this.catch((e) => (n === 0 ? KIO.fail(e) : loop(n - 1)));
-          };
-          return loop(times);
-        }
-      }
-    })();
+  retryN(times: number): KIO<E, A> {
+    const loop = (n: number): KIO<E, A> => {
+      return this.catch((e) => (n === 0 ? KIO.fail(e) : loop(n - 1)));
+    };
+    return loop(times);
   }
 
   /**

--- a/packages/core/src/retry/policy.ts
+++ b/packages/core/src/retry/policy.ts
@@ -1,6 +1,0 @@
-export type Recurs = {
-  kind: "Recurs";
-  times: number;
-};
-
-export type RetryPolicy = Recurs;

--- a/packages/core/src/runner/runner.spec.ts
+++ b/packages/core/src/runner/runner.spec.ts
@@ -119,7 +119,7 @@ describe("PromiseRunner", () => {
         const kio = KIO.start()
           .andThen(() => KIO.succeed(i++))
           .andThen(() => KIO.fail("error"))
-          .retry({ kind: "Recurs", times: 2 })
+          .retryN(2)
           .catch(() => KIO.succeed(i));
         const result = await runner.run(kio);
         expect(result).toBe(3);


### PR DESCRIPTION
## Summary
- Replace `retry(RetryPolicy)` with `retryN(times: number)` for cleaner API
- Remove `RetryPolicy` type and `retry/policy.ts` file since only one retry strategy exists
- Update test to use new `retryN` method

## Changes
- **Before**: `.retry({ kind: "Recurs", times: 3 })`
- **After**: `.retryN(3)`

This simplifies the API since there's currently only one retry strategy (Recurs). If more retry strategies are needed in the future, they can be added as separate methods like `retryExponential()`, etc.

## Test plan
- [x] Existing retry test updated and passing
- [x] All functionality preserved with cleaner API

🤖 Generated with [Claude Code](https://claude.ai/code)