### PR TITLE
refactor: remove KIO.start() method and update devcontainer setup

### DIFF
--- a/packages/core/src/kio.ts
+++ b/packages/core/src/kio.ts
@@ -163,18 +163,6 @@ export class KIO<E, A> {
     this.kioa = kioa;
   }
 
-  /**
-   * Creates an effect that represents a successful operation with no value.
-   * @returns An effect with no value
-   *
-   * @example
-   * ```typescript
-   * const kio = KIO.start();
-   * ```
-   */
-  static start(): KIO<never, void> {
-    return new KIO({ kind: "Succeed", value: undefined });
-  }
 
   /**
    * Creates an effect that represents a successful operation with a value.
@@ -354,7 +342,7 @@ export class KIO<E, A> {
         return next.value.andThen((a) => loop(itr, a));
       }
     };
-    return KIO.start().andThen(() => loop(f()));
+    return loop(f());
   }
 
   /**

--- a/packages/core/src/runner/runner.spec.ts
+++ b/packages/core/src/runner/runner.spec.ts
@@ -91,8 +91,7 @@ describe("PromiseRunner", () => {
         }
       });
       it("Fold", async () => {
-        const kio = KIO.start()
-          .andThen(() => KIO.succeed(1))
+        const kio = KIO.succeed(1)
           .andThen(() => KIO.fail("error"))
           .fold(
             () => {
@@ -116,8 +115,7 @@ describe("PromiseRunner", () => {
       });
       it("Retry", async () => {
         let i = 0;
-        const kio = KIO.start()
-          .andThen(() => KIO.succeed(i++))
+        const kio = KIO.async(async () => i++)
           .andThen(() => KIO.fail("error"))
           .retryN(2)
           .catch(() => KIO.succeed(i));

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -14,7 +14,7 @@ const client = new KintoneRestAPIClient({
 const runner = createRunner(client);
 
 const action = (taskName: string) =>
-  addTask(taskName).retry({ kind: "Recurs", times: 2 });
+  addTask(taskName).retryN(2);
 
 const result = await Promise.all([
   runner.run(action("Task 1").catch((e) => KIO.succeed(e))),

--- a/packages/example/src/methodChainingStyle/addTask.ts
+++ b/packages/example/src/methodChainingStyle/addTask.ts
@@ -6,11 +6,7 @@ export const addTask = (taskName: string) => {
   const startsAt = new Date("2025-03-30T07:00:00Z");
   const endsAt = new Date("2025-03-30T08:00:00Z");
 
-  return KIO.start()
-    .andThen(() => {
-      console.log(`Adding task: ${taskName}`);
-      return KIO.succeed(undefined);
-    })
+  return KIO.async(async () => console.log(`Adding task: ${taskName}`))
     .andThen(() =>
       KIO.getRecords<TaskRegistrationStatus>({
         app: process.env.TASK_REG_STATUS_APP_ID ?? "",

--- a/packages/example/src/pipeStyle/addTask.ts
+++ b/packages/example/src/pipeStyle/addTask.ts
@@ -7,11 +7,7 @@ export const addTask = (taskName: string) => {
   const endsAt = new Date("2025-03-30T08:00:00Z");
 
   return pipe(
-    KIO.start(),
-    KIO.andThen(() => {
-      console.log(`Adding task: ${taskName}`);
-      return KIO.succeed(undefined);
-    }),
+    KIO.async(async () => console.log(`Adding task: ${taskName}`)),
     KIO.andThen(() =>
       KIO.getRecords<TaskRegistrationStatus>({
         app: process.env.TASK_REG_STATUS_APP_ID ?? "",


### PR DESCRIPTION
## Summary
- Remove deprecated `KIO.start()` method from core API
- Update examples to use direct method calls instead of chaining from `start()`
- Improve devcontainer configuration with custom Node.js setup using fnm
- Add `.nvmrc` file for Node.js version management

## Changes
- **Core API**: Removed `KIO.start()` method and updated `iterate` implementation
- **Examples**: Updated method chaining and pipe style examples to use `KIO.async()` and direct calls
- **DevContainer**: Enhanced setup with custom Dockerfile, fnm installation, and post-create script
- **Configuration**: Added Node.js version specification via `.nvmrc`

## Test plan
- [x] Verify examples still work with updated API
- [x] Ensure devcontainer builds and runs correctly
- [x] Confirm all tests pass with the refactored code

🤖 Generated with [Claude Code](https://claude.ai/code)